### PR TITLE
Fix render npm start path

### DIFF
--- a/Backend/README.md
+++ b/Backend/README.md
@@ -6,5 +6,6 @@ Turns a **public** Instagram post URL into direct CDN image links – no API tok
 
 ```bash
 npm install
-node index.js
+npm start
 # open http://localhost:3000/api/ig?link=https://www.instagram.com/p/Cv5tmDXKfTI/
+```

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,11 @@
+{
+  "name": "ig-proxy-root",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "ig-proxy-root",
+      "hasInstallScript": true
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "ig-proxy-root",
+  "private": true,
+  "scripts": {
+    "start": "node Backend/index.js",
+    "install": "npm install --prefix Backend"
+  }
+}

--- a/render.yaml
+++ b/render.yaml
@@ -1,0 +1,9 @@
+services:
+  - type: web
+    name: ctrlv-ig
+    env: node
+    plan: free
+    buildCommand: "npm install"
+    startCommand: "npm start"
+    branch: main
+    healthCheckPath: "/api/ig?link=https://www.instagram.com/p/Cv5tmDXKfTI/"


### PR DESCRIPTION
## Summary
- add a root `package.json` that delegates to the Backend folder
- include a root `render.yaml` so Render runs from repo root
- update backend README to use `npm start`

## Testing
- `npm install`
- `npm start`

------
https://chatgpt.com/codex/tasks/task_e_68405a013a6c833284ac505688c780f8