### PR TITLE
Serve frontend in IG proxy

### DIFF
--- a/Backend/index.js
+++ b/Backend/index.js
@@ -1,8 +1,19 @@
 import express from "express";
 import fetch from "node-fetch";
+import path from "path";
+import { fileURLToPath } from "url";
 
 const app = express();
 const UA = "Mozilla/5.0 Chrome/124 Safari/537.36";
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+// Serve static frontend
+const frontPath = path.join(__dirname, "..", "Frontend");
+app.use(express.static(frontPath));
+
+app.get("/", (req, res) => {
+  res.sendFile(path.join(frontPath, "index.html"));
+});
 
 app.get("/api/ig", async (req, res) => {
   const link = req.query.link?.trim();


### PR DESCRIPTION
## Summary
- serve the `Frontend` folder via Express
- add `/` route to return `index.html`

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68405b1a04a8833280bd71d1e9e4da37