### PR TITLE
Fix global pip install issue

### DIFF
--- a/Backend/README.md
+++ b/Backend/README.md
@@ -11,4 +11,4 @@ npm start
 ```
 
 Make sure Python and `instaloader` are available. The install script will automatically
-run `pip install instaloader`.
+run `pip install --user instaloader`.

--- a/package.json
+++ b/package.json
@@ -3,6 +3,6 @@
   "private": true,
   "scripts": {
     "start": "node Backend/index.js",
-    "install": "npm install --prefix Backend && pip install instaloader"
+    "install": "npm install --prefix Backend && pip install --user instaloader"
   }
 }


### PR DESCRIPTION
## Summary
- ensure pip installs Instaloader to the user directory
- update local instructions

## Testing
- `npm test` *(fails: Missing script)*
- `npm install`

------
https://chatgpt.com/codex/tasks/task_e_684065bf6c588332b6d9c535e9b210fa